### PR TITLE
PLATUI-352 Add case class ops/reflect for example generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val libDependencies: Seq[ModuleID] = dependencies(
   play25 = {
     val compile = Seq(
       "uk.gov.hmrc" %% "play-frontend-govuk" % "0.32.0-play-25",
-      "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.7.0-play-25"
+      "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.9.0-play-25"
     )
 
     val test = Seq(
@@ -106,7 +106,7 @@ lazy val libDependencies: Seq[ModuleID] = dependencies(
   play26 = {
     val compile = Seq(
       "uk.gov.hmrc" %% "play-frontend-govuk" % "0.32.0-play-26",
-      "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.7.0-play-26"
+      "uk.gov.hmrc" %% "play-frontend-hmrc" % "0.9.0-play-26"
     )
 
     val test = Seq(

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOps.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOps.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.examples
+
+import java.lang.reflect.{Method, Field => JField}
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.currentMirror
+import scala.util.matching.Regex
+
+case class Field[+T](
+                     name: String,
+                     value: T,
+                     defaultValue: Option[T],
+                     isConstructorVal: Boolean
+                   ) {
+}
+
+case class CaseClassOps[T <: Product : ClassTag](caseClassObj: T) {
+
+  private val caseClass = caseClassObj.getClass
+  private val caseClassMirror = currentMirror.reflect(caseClassObj)
+
+  private val companionObjInstance: Any = {
+    val classLoader = caseClass.getClassLoader
+    val companionObj = classLoader.loadClass(s"${caseClass.getName}$$")
+
+    val moduleMaybe = companionObj.getDeclaredFields.find(_.getName == "MODULE$")
+    moduleMaybe match {
+      case Some(module) => module.get(true)
+      case _ =>
+        val outerModule = caseClass.getFields.find(_.getName.contains("$")).get.get(caseClassObj)
+        val moduleMirror = currentMirror.reflect(outerModule)
+
+        val companionSymbol = caseClassMirror.symbol.companion.asModule
+        moduleMirror.reflectModule(companionSymbol).instance
+    }
+  }
+
+  val javaFields: Array[JField] = {
+    val fields = caseClass
+      .getDeclaredFields
+      .filterNot(f => f.isSynthetic | f.getName.contains("serialVersionUID"))
+    fields.foreach(_.setAccessible(true))
+    fields
+  }
+
+  private val jFieldTrueNames: Map[JField, String] = {
+    val nonPublicField: Regex = """.*?\$\$(\w*)$""".r
+
+    val kvps = for {
+      field <- javaFields
+      fieldName = field.getName match {
+        case nonPublicField(trueName) => trueName
+        case f@_ => f
+      }
+    } yield field -> fieldName
+
+    kvps.toMap
+  }
+
+  private val caseAccessors: Iterable[String] = {
+    val nonPublicCaseAccessor: Regex = """(.*?)\$\d+$""".r
+
+    val members = caseClassMirror
+      .symbol
+      .typeSignature
+      .members
+
+    for {
+      member <- members
+      if member.isMethod
+      methodSymbol = member.asMethod
+      if methodSymbol.isCaseAccessor
+      fieldName = methodSymbol.name.toString
+    } yield fieldName match {
+      case nonPublicCaseAccessor(trueName) => trueName
+      case _ => fieldName
+    }
+  }
+
+  private val defaults: Map[String, Any] = {
+    val fieldNames: Seq[String] = javaFields.map(jFieldTrueNames)
+    val kvps = for {
+      compObjMethod: Method <- companionObjInstance.getClass.getDeclaredMethods
+      javaMethodName: String = compObjMethod.getName
+      defaultParamIndex <-
+        """\$lessinit\$greater\$default\$(\d+)""".r
+          .findFirstMatchIn(javaMethodName)
+          .toIterable
+          .flatMap(_.subgroups)
+          .map(_.toInt - 1)
+      field: String = fieldNames(defaultParamIndex)
+      default: Any = compObjMethod.invoke(companionObjInstance)
+    } yield field -> default
+
+    kvps.toMap
+  }
+
+  val fields: List[Field[Any]] = {
+    val array = for {
+      jField <- javaFields
+      fieldName = jFieldTrueNames(jField)
+      value = jField.get(caseClassObj)
+      isConstructorVal = caseAccessors.toSeq.contains(fieldName)
+      defaultValue = if (isConstructorVal) defaults.get(fieldName) else Some(value)
+    } yield Field(
+      name = fieldName,
+      value = value,
+      defaultValue = defaultValue,
+      isConstructorVal = isConstructorVal
+    )
+
+    array.toList
+  }
+
+  val constructorFields: List[Field[Any]] = fields.filter(_.isConstructorVal)
+  val customisedFields: List[Field[Any]] = fields.filterNot(f => f.defaultValue.contains(f.value))
+  val customisedConstructorFields: List[Field[Any]] = customisedFields.filter(_.isConstructorVal)
+
+}

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/examples/Implicits.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/examples/Implicits.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.examples
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+import scala.reflect.runtime.currentMirror
+import scala.util.Try
+
+object Implicits {
+
+  implicit def withCaseClassOps[T <: Product : ClassTag](caseClassObj: T): CaseClassOps[T] = {
+    if (!caseClassObj.isCaseClass)
+      throw new Exception(s"Product [$caseClassObj] is not a case class - please limit the scope of implicit conversion or directly create CaseClassOps appropriately.")
+    else
+      CaseClassOps(caseClassObj)
+  }
+
+  implicit class ProductOps[T <: Product : ClassTag](product: T) {
+
+    val isCaseType: Boolean = currentMirror.reflect(product).symbol.isCaseClass
+
+    private val hasCompanionObject: Boolean = {
+      val productClass: Class[_ <: T] = product.getClass
+      val classLoader = productClass.getClassLoader
+      Try(classLoader.loadClass(s"${productClass.getName}$$")).isSuccess
+    }
+
+    val isCaseClass: Boolean = isCaseType && hasCompanionObject
+
+    val isCaseObject: Boolean = isCaseType && !hasCompanionObject
+
+    def asCaseClassOps: Option[CaseClassOps[T]] = if (isCaseClass) Some(CaseClassOps(product)) else None
+
+  }
+
+}

--- a/src/test/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/examples/signout/example.scala.html
+++ b/src/test/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/examples/signout/example.scala.html
@@ -2,3 +2,8 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 
 @()
+
+@HmrcHeader(Header(
+    serviceName = Some("Service Name"),
+    serviceUrl = "/"
+  ))

--- a/src/test/play-26/twirl/uk/gov/hmrc/hmrcfrontend/views/examples/signout/example.scala.html
+++ b/src/test/play-26/twirl/uk/gov/hmrc/hmrcfrontend/views/examples/signout/example.scala.html
@@ -3,3 +3,9 @@
 @this(hmrcHeader : HmrcHeader)
 
 @()
+
+
+@hmrcHeader(Header(
+    serviceName = Some("Service Name"),
+    serviceUrl = "/"
+  ))

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOpsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOpsSpec.scala
@@ -1,0 +1,736 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.examples
+
+import org.scalatest.{Matchers, WordSpec}
+
+class CaseClassOpsSpec extends WordSpec with Matchers {
+
+  sealed trait Abstract {
+    val zero: String
+    val six: Float
+    val thirteen: Option[String]
+    protected val fifteen: Option[Float]
+  }
+
+  case class TestCaseClass(
+                   zero: String,
+                   one: Boolean = true,
+                   two: Int = 2,
+                   three: Option[Int] = None,
+                   four: List[Int] = List(4),
+                   five: Double,
+                   six: Float,
+                   seven: BigDecimal,
+                   eight: String = "eight",
+                   nine: Int,
+                   ten: Option[Int] = Some(10),
+                   private val eleven: String,
+                   protected val twelve: Int
+                 ) extends Abstract {
+    val thirteen: Option[String] = Some("thirteen")
+    private val fourteen: Option[Double] = Some(14)
+    protected val fifteen: Option[Float] = Some(15)
+  }
+
+  val testOne: TestCaseClass = TestCaseClass(
+    zero = "zero",
+    five = 5,
+    six = 6,
+    seven = 7,
+    nine = 9,
+    eleven = "eleven",
+    twelve = 12
+  )
+  
+  val testOneOps: CaseClassOps[TestCaseClass] = CaseClassOps(testOne)
+
+  val testTwo: TestCaseClass = TestCaseClass(
+    zero = "zero",
+    one = false,
+    two = 22222,
+    three = Some(3),
+    five = 5,
+    six = 6,
+    seven = 7,
+    nine = 9,
+    ten = None,
+    eleven = "eleven",
+    twelve = 12
+  )
+
+  val testTwoOps: CaseClassOps[TestCaseClass] = CaseClassOps(testTwo)
+  
+  "fields" should {
+
+    """provide a list of all defined fields in a case class,
+       |their names, their values, their default values and
+       |whether they are used in the case class constructor,
+       |all in the order they are defined""".stripMargin in {
+
+      val expectedTestOneFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = true,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 2,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = None,
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[List[Int]](
+          name = "four",
+          value = List(4),
+          defaultValue = Some(List(4)),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eight",
+          value = "eight",
+          defaultValue = Some("eight"),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = Some(10),
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[String]](
+          name = "thirteen",
+          value = Some("thirteen"),
+          defaultValue = Some(Some("thirteen")),
+          isConstructorVal = false
+        ),
+        Field[Option[Double]](
+          name = "fourteen",
+          value = Some(14),
+          defaultValue = Some(Some(14)),
+          isConstructorVal = false
+        ),
+        Field[Option[Float]](
+          name = "fifteen",
+          value = Some(15),
+          defaultValue = Some(Some(15)),
+          isConstructorVal = false
+        )
+      )
+
+      val testOneFields: List[Field[Any]] = testOneOps.fields
+
+      val expectedTestTwoFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = false,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 22222,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = Some(3),
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[List[Int]](
+          name = "four",
+          value = List(4),
+          defaultValue = Some(List(4)),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eight",
+          value = "eight",
+          defaultValue = Some("eight"),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = None,
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[String]](
+          name = "thirteen",
+          value = Some("thirteen"),
+          defaultValue = Some(Some("thirteen")),
+          isConstructorVal = false
+        ),
+        Field[Option[Double]](
+          name = "fourteen",
+          value = Some(14),
+          defaultValue = Some(Some(14)),
+          isConstructorVal = false
+        ),
+        Field[Option[Float]](
+          name = "fifteen",
+          value = Some(15),
+          defaultValue = Some(Some(15)),
+          isConstructorVal = false
+        )
+      )
+
+      val testTwoFields: List[Field[Any]] = testTwoOps.fields
+
+      testOneFields shouldBe expectedTestOneFields
+
+      testTwoFields shouldBe expectedTestTwoFields
+
+    }
+  }
+
+  "constructorFields" should {
+
+    """provide a list of all constructor fields in a case class in the order they are defined""" in {
+
+      val expectedTestOneConstructorFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = true,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 2,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = None,
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[List[Int]](
+          name = "four",
+          value = List(4),
+          defaultValue = Some(List(4)),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eight",
+          value = "eight",
+          defaultValue = Some("eight"),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = Some(10),
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testOneConstructorFields: List[Field[Any]] = testOneOps.constructorFields
+
+      val expectedTestTwoConstructorFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = false,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 22222,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = Some(3),
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[List[Int]](
+          name = "four",
+          value = List(4),
+          defaultValue = Some(List(4)),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eight",
+          value = "eight",
+          defaultValue = Some("eight"),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = None,
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testTwoConstructorFields: List[Field[Any]] = testTwoOps.constructorFields
+
+      testOneConstructorFields shouldBe expectedTestOneConstructorFields
+
+      testTwoConstructorFields shouldBe expectedTestTwoConstructorFields
+
+    }
+
+  }
+
+  "customisedFields" should {
+
+    """provide a list of all fields in a case class
+      |in the order they are defined if they are
+      |different from any set default value for that field""".stripMargin in {
+
+      val expectedTestOneCustomisedFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testOneCustomisedFields: List[Field[Any]] = testOneOps.customisedFields
+
+      val expectedTestTwoCustomisedFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = false,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 22222,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = Some(3),
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = None,
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testTwoCustomisedFields: List[Field[Any]] = testTwoOps.customisedFields
+
+      testOneCustomisedFields shouldBe expectedTestOneCustomisedFields
+
+      testTwoCustomisedFields shouldBe expectedTestTwoCustomisedFields
+
+    }
+
+  }
+
+  "customisedConstructorFields" should {
+
+    """provide a list of all constructor fields in a case
+      |class in the order they are defined if they are
+      |different from any set default value for that field""".stripMargin in {
+
+      val expectedTestOneCustomisedConstructorFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testOneCustomisedConstructorFields: List[Field[Any]] = testOneOps.customisedConstructorFields
+
+      val expectedTestTwoCustomisedConstructorFields: List[Field[Any]] = List(
+        Field[String](
+          name = "zero",
+          value = "zero",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Boolean](
+          name = "one",
+          value = false,
+          defaultValue = Some(true),
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "two",
+          value = 22222,
+          defaultValue = Some(2),
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "three",
+          value = Some(3),
+          defaultValue = Some(None),
+          isConstructorVal = true
+        ),
+        Field[Double](
+          name = "five",
+          value = 5,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Float](
+          name = "six",
+          value = 6,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[BigDecimal](
+          name = "seven",
+          value = 7,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "nine",
+          value = 9,
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Option[Int]](
+          name = "ten",
+          value = None,
+          defaultValue = Some(Some(10)),
+          isConstructorVal = true
+        ),
+        Field[String](
+          name = "eleven",
+          value = "eleven",
+          defaultValue = None,
+          isConstructorVal = true
+        ),
+        Field[Int](
+          name = "twelve",
+          value = 12,
+          defaultValue = None,
+          isConstructorVal = true
+        )
+      )
+
+      val testTwoCustomisedConstructorFields: List[Field[Any]] = testTwoOps.customisedConstructorFields
+
+      testOneCustomisedConstructorFields shouldBe expectedTestOneCustomisedConstructorFields
+
+      testTwoCustomisedConstructorFields shouldBe expectedTestTwoCustomisedConstructorFields
+
+    }
+
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/examples/ImplicitsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/examples/ImplicitsSpec.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.examples
+
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.{Failure, Success, Try}
+
+class ImplicitsSpec extends WordSpec with Matchers {
+
+  trait Abstract
+
+  case class TestCaseClass() extends Abstract
+  case object TestCaseObject extends Abstract
+
+  class NonCaseClassProduct extends Product {
+    override def productElement(n: Int): Any = throw new Exception
+    override def productArity: Int = throw new Exception
+    override def canEqual(that: Any): Boolean = throw new Exception
+  }
+
+  val testCaseClass: TestCaseClass = TestCaseClass()
+  val nonCaseClassProduct: NonCaseClassProduct = new NonCaseClassProduct
+
+  "withCaseClassOps" should {
+
+    "wrap case class with case class ops when imported" in {
+      import uk.gov.hmrc.govukfrontend.examples.Implicits.withCaseClassOps
+
+      Try {
+        val foo: CaseClassOps[_] = testCaseClass
+      } match {
+        case Success(_) => succeed
+        case _ => fail
+      }
+    }
+
+    "raise an Exception if attempting to import with case object in scope" in {
+      import uk.gov.hmrc.govukfrontend.examples.Implicits.withCaseClassOps
+
+      Try {
+        val foo: CaseClassOps[_] = TestCaseObject
+      } match {
+        case Failure(_) => succeed
+        case _ => fail
+      }
+    }
+
+    "raise an Exception if attempting to import with other invalid Product in scope" in {
+      import uk.gov.hmrc.govukfrontend.examples.Implicits.withCaseClassOps
+      Try {
+        val foo: CaseClassOps[_] = nonCaseClassProduct
+      } match {
+        case Failure(_) => succeed
+        case _ => fail
+      }
+    }
+
+  }
+
+  "ProductOps" should {
+
+    import uk.gov.hmrc.govukfrontend.examples.Implicits.ProductOps
+
+    "isCaseType" should {
+
+      "return true for case classes" in {
+        testCaseClass.isCaseType shouldBe true
+      }
+
+      "return true for case objects" in {
+        TestCaseObject.isCaseType shouldBe true
+      }
+
+      "return false otherwise" in {
+        nonCaseClassProduct.isCaseType shouldBe false
+      }
+
+    }
+
+    "isCaseClass" should {
+
+      "return true for case classes" in {
+        testCaseClass.isCaseClass shouldBe true
+      }
+
+      "return false for case objects" in {
+        TestCaseObject.isCaseClass shouldBe false
+      }
+
+      "return false otherwise" in {
+        nonCaseClassProduct.isCaseClass shouldBe false
+      }
+
+    }
+
+    "isCaseObject" should {
+
+      "return false for case classes" in {
+        testCaseClass.isCaseObject shouldBe false
+      }
+
+      "return true for case objects" in {
+        TestCaseObject.isCaseObject shouldBe true
+      }
+
+      "return false otherwise" in {
+        nonCaseClassProduct.isCaseObject shouldBe false
+      }
+
+    }
+
+    "asCaseClassOps" should {
+
+      "return Some(CaseClassOps) for case classes" in {
+        testCaseClass.asCaseClassOps match {
+          case Some(_: CaseClassOps[_]) => succeed
+          case _ => fail
+        }
+      }
+
+      "return None for case objects" in {
+        TestCaseObject.asCaseClassOps match {
+          case None => succeed
+          case _ => fail
+        }
+      }
+
+      "return None otherwise" in {
+        nonCaseClassProduct.asCaseClassOps match {
+          case None => succeed
+          case _ => fail
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/examples/TwirlFormatterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/examples/TwirlFormatterSpec.scala
@@ -2354,9 +2354,9 @@ class TwirlFormatterSpec extends WordSpec with Matchers {
       gouvukTextareaTwirl.trimSpaces shouldBe govukTextareaTwirlExpected.trimSpaces
     }
 
-    "format hmrcHeader " ignore {
+    "format HmrcHeader " in {
 
-      val gouvukTextareaNunjucks =
+      val hmrcHeaderNunjucks =
         """---
           |layout: layout-example.njk
           |---
@@ -2369,13 +2369,20 @@ class TwirlFormatterSpec extends WordSpec with Matchers {
           |    "signOut" : true
           |}) }}""".stripMargin
 
-      val govukTextareaTwirlExpected =
-        """""".stripMargin
+      val hmrcHeaderTwirlExpected =
+        """@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+          |
+          |@()
+          |
+          |@HmrcHeader(Header(
+          |  serviceName = Some("Service Name"),
+          |  serviceUrl = "/"
+          |))""".stripMargin
 
-      val gouvukTextareaParsed = fastparse.parse(gouvukTextareaNunjucks, NunjucksParser.nunjucksParser(_))
-      val gouvukTextareaTwirl  = formatPlay25(gouvukTextareaParsed.get.value)
-      gouvukTextareaTwirl.print
-      gouvukTextareaTwirl.trimSpaces shouldBe govukTextareaTwirlExpected.trimSpaces
+      val hmrcHeaderParsed = fastparse.parse(hmrcHeaderNunjucks, NunjucksParser.nunjucksParser(_))
+      val hmrcHeaderTwirl  = formatPlay25(hmrcHeaderParsed.get.value)
+      hmrcHeaderTwirl.print
+      hmrcHeaderTwirl.trimSpaces shouldBe hmrcHeaderTwirlExpected.trimSpaces
     }
 
   }
@@ -4255,6 +4262,38 @@ class TwirlFormatterSpec extends WordSpec with Matchers {
       val gouvukTextareaTwirl  = format(gouvukTextareaParsed.get.value)
       gouvukTextareaTwirl.print
       gouvukTextareaTwirl.trimSpaces shouldBe govukTextareaTwirlExpected.trimSpaces
+    }
+
+    "format HmrcHeader " in {
+
+      val hmrcHeaderNunjucks =
+        """---
+          |layout: layout-example.njk
+          |---
+          |{% from "hmrc/components/header/macro.njk" import hmrcHeader %}
+          |
+          |{{ hmrcHeader({
+          |    "serviceName": "Service Name",
+          |    "serviceUrl" : "/",
+          |    "phaseBanner" : true,
+          |    "signOut" : true
+          |}) }}""".stripMargin
+
+      val hmrcHeaderTwirlExpected =
+        """@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+          |
+          |@this(hmrcHeader: HmrcHeader)
+          |
+          |@()
+          |@hmrcHeader(Header(
+          |  serviceName = Some("Service Name"),
+          |  serviceUrl = "/"
+          |))""".stripMargin
+
+      val hmrcHeaderParsed = fastparse.parse(hmrcHeaderNunjucks, NunjucksParser.nunjucksParser(_))
+      val hmrcHeaderTwirl  = format(hmrcHeaderParsed.get.value)
+      hmrcHeaderTwirl.print
+      hmrcHeaderTwirl.trimSpaces shouldBe hmrcHeaderTwirlExpected.trimSpaces
     }
 
   }


### PR DESCRIPTION
To identify:
- Default values
- Constructor values
- Obtain values for private values

This allows more effective pretty
printing.

Also added test for HmrcHeader
component in TwirlFormatterSpec.

Also bumped up play-frontend-hmrc
version to pull in fixes.