### PR TITLE
PLATUI-345 Allow cross-compilation with Scala 2.12

### DIFF
--- a/src/main/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOps.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/examples/CaseClassOps.scala
@@ -74,7 +74,7 @@ case class CaseClassOps[T <: Product : ClassTag](caseClassObj: T) {
   }
 
   private val caseAccessors: Iterable[String] = {
-    val nonPublicCaseAccessor: Regex = """(.*?)\$\d+$""".r
+    val nonPublicCaseAccessor: Regex = """^([^$]*).*$""".r
 
     val members = caseClassMirror
       .symbol


### PR DESCRIPTION
Naming of Scala methods in Java differs - make regex
more general to work for both Scala 2.11 and 2.12